### PR TITLE
Add missing dependncy on the Servo library

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=The server for the Telemetrix Project.
 paragraph=This sketch is a server for the telemetrix and telemetrix-aio Python clients. It provides remote control and monitoring of Arduino-Core devices.
 category=Device Control
 url=https://github.com/MrYsLab/Telemetrix4Arduino
-depends=Ultrasonic, DHTStable, OneWire, AccelStepper
+depends=Ultrasonic, DHTStable, OneWire, AccelStepper, Servo
 architectures=*


### PR DESCRIPTION
There is a missing dependency on the Servo library, making the build fail if it's not installed. This should fix it.